### PR TITLE
Fix wrong CamelCasing translation of API name

### DIFF
--- a/src/factomd.js
+++ b/src/factomd.js
@@ -235,11 +235,11 @@ Factomd.prototype.factoidBlock = function (keyMr) {
 /**
  * Retrieve a specified entrycredit block given its merkle root key.
  * The numbers are minute markers.
- * @method entryCreditBlock
+ * @method entrycreditBlock
  * @param {String} keyMr Merkle root key
  *
  */
-Factomd.prototype.entryCreditBlock = function (keyMR) {
+Factomd.prototype.entrycreditBlock = function (keyMR) {
   const jdata = {'jsonrpc': '2.0',
     'id': this.APICounter(),
     'method': 'entrycredit-block',

--- a/test/factomdtest.js
+++ b/test/factomdtest.js
@@ -103,11 +103,11 @@ describe('factomd.factoidBlock', function () {
   })
 })
 
-describe('factomd.entryCreditBlock', function () {
-  it('should call factomd.entryCreditBlock', function (done) {
+describe('factomd.entrycreditBlock', function () {
+  it('should call factomd.entrycreditBlock', function (done) {
     assert.doesNotThrow(async function () {
       var keymr = '2050b16701f29238d6b99bcf3fb0ca55d6d884139601f06691fc370cda659d60'
-      var response = await factomd.entryCreditBlock(keymr)
+      var response = await factomd.entrycreditBlock(keymr)
       console.log(JSON.stringify(response))
       done()
     }, done)


### PR DESCRIPTION
All the methods are a CamelCase version of the Factomd API name string, except for `entrycredit-block` which once this string is CamelCased should become `entrycreditBlock` and not `entryCreditBlock`. For instance it's inconsistent with the method `ablockByHeight` which otherwise should be `aBlockByHeight` if following the same standard as `entryCreditBlock`. 